### PR TITLE
Add Basic Functionality for Fairlight Audio

### DIFF
--- a/PyATEMMax/ATEMProtocol.py
+++ b/PyATEMMax/ATEMProtocol.py
@@ -77,6 +77,11 @@ class ATEMProtocol:
     dVETransitionStyles = ATEMDVETransitionStyles()
     dsks = ATEMDSKs()
     externalPortTypes = ATEMExternalPortTypes()
+    fairlightMixerInputMixOptions = ATEMFairlightMixerInputMixOptions()
+    fairlightMixerInputTypes = ATEMFairlightMixerInputTypes()
+    fairlightMixerSourceTypes = ATEMFairlightMixerSourceTypes()
+    fairlightEQFilters = ATEMFairlightEQFilters()
+    fairlightEQFrequencyRanges = ATEMFairlightEQFrequencyRanges()
     keyers = ATEMKeyers()
     keyerTypes = ATEMKeyerTypes()
     keyFrames = ATEMKeyFrames()
@@ -161,6 +166,15 @@ class ATEMProtocol:
         "AMTl": 'Audio Mixer Tally',
         "TlIn": 'Tally By Index',
         "TlSr": 'Tally By Source',
+
+        # Fairlight audio engine commands
+        'FASP': 'Fairlight Audio Mixer Input',
+        'AEBP': "Fairlight Audio Input EQ Bands",
+        'FAMP': 'Fairlight Audio Mixer Master',
+        'AMBP': "Fairlight Audio Master EQ Bands",
+        # 'FMLv': "Fairlight Audio Input Level",
+        # 'FMTl': 'Fairlight Tally Command',
+
         "Time": 'Last State Change Time Code',
         'InCm': 'Initialization Complete',
 

--- a/PyATEMMax/ATEMProtocolEnums.py
+++ b/PyATEMMax/ATEMProtocolEnums.py
@@ -322,6 +322,67 @@ class ATEMAudioMixerInputTypes(ATEMConstantList):
     externalAudio = ATEMConstant('externalAudio', 2)
 
 
+class ATEMFairlightMixerInputMixOptions(ATEMConstantList):
+    """FairlightMixerInputMixOption list"""
+
+    off = ATEMConstant('off', 1)
+    on = ATEMConstant('on', 2)
+    afv = ATEMConstant('afv', 4)
+
+
+class ATEMFairlightMixerInputTypes(ATEMConstantList):
+    """FairlightMixerInputType list"""
+
+    externalVideo = ATEMConstant('externalVideo', 0)
+    mediaPlayer = ATEMConstant('mediaPlayer', 1)
+    externalAudio = ATEMConstant('externalAudio', 2)
+    MADI = ATEMConstant('MADI', 3)
+
+
+class ATEMFairlightMixerSourceTypes(ATEMConstantList):
+    """ATEMFairlightMixerSourceType list
+    Converted from signed to unsigned to allow easier parsing
+    """
+
+    stereo = ATEMConstant('stereo', 18446744073709486336)
+    mono1 = ATEMConstant('mono1', 18446744073709551360)
+    mono2 = ATEMConstant('mono2', 18446744073709551361)
+
+
+class ATEMFairlightEQFilters(ATEMConstantList):
+    """ATEMFairlightEQFilters list
+
+    https://iconcollective.edu/types-of-eq/ has good explainations
+    of what the different filters do.
+    """
+
+    lowShelf = ATEMConstant('lowShelf',     1 << 0)
+    highCut = ATEMConstant('highCut',       1 << 1)
+    bellCurve = ATEMConstant('bellCurve',   1 << 2)
+    notch = ATEMConstant('notch',           1 << 3)
+    lowCut = ATEMConstant('lowCut',         1 << 4)
+    highShelf = ATEMConstant('highShelf',   1 << 5)
+
+
+class ATEMFairlightEQFrequencyRanges(ATEMConstantList):
+    """ATEMFairlightEQFrequencyRanges list
+
+    ---
+    | Frequency Range | Min Freq | Max Freq |
+    |-----------------|----------|----------|
+    | low             |       30 |      395 |
+    | midlow          |      100 |     1480 |
+    | midhigh         |      450 |     7910 |
+    | high            |     1400 |    21700 |
+    ---
+    """
+
+    low = ATEMConstant('low',           1 << 0)
+    midlow = ATEMConstant('midlow',     1 << 1)
+    midhigh = ATEMConstant('midhigh',   1 << 2)
+    high = ATEMConstant('high',         1 << 3)
+
+
 class ATEMAudioMixerInputPlugTypes(ATEMConstantList):
     """AudioMixerInputPlugType list"""
 

--- a/PyATEMMax/ATEMSetterMethods.py
+++ b/PyATEMMax/ATEMSetterMethods.py
@@ -13,6 +13,7 @@ from typing import Union
 
 from .ATEMUtils import mapValue
 from .ATEMProtocolEnums import *
+from .StateData import FairlightMixer
 
 # --------------------------------------------------
 # This is a trick to have type hints from classes
@@ -44,6 +45,7 @@ class ATEMSetterMethods():
         self.switcher: ATEMConnectionManager
         self.data: ATEMSwitcherState
         self.atem: ATEMProtocol
+        self.fairlightMixer: FairlightMixer
 
 
     # #######################################################################
@@ -4088,4 +4090,493 @@ class ATEMSetterMethods():
         self.switcher._prepareCommandPacket("RAMP", 8)
         self.switcher._outBuf.setU8Flag(0, 2)
         self.switcher._outBuf.setU8(4, master)
+        self.switcher._finishCommandPacket()
+
+
+    def setFairlightMixerInputMixOption(self, audioSource: Union[ATEMConstant, str, int], mixOption: Union[ATEMConstant, str, int]) -> None:
+        """Set Fairlight Mixer Input Mix Option
+
+        Args:
+            audioSource: see ATEMAudioSources
+            mixOption: see ATEMFairlightMixerInputMixOptions
+        """
+        audioSource_val = self.atem.getAudioSrc(audioSource)
+        mixOption_val = self.atem.fairlightMixerInputMixOptions[mixOption].value
+
+        self.switcher._prepareCommandPacket("CFSP", 48)
+        self.switcher._outBuf.setU16Flag(0, 8)
+        self.switcher._outBuf.setU16(2, audioSource_val)
+        self.switcher._outBuf.setS64(8, -65280) # Hacky fix to assume stereo
+
+        self.switcher._outBuf.setU8(44, mixOption_val)
+
+        self.switcher._finishCommandPacket()
+
+
+    def setFairlightMixerInputVolume(self, audioSource: Union[ATEMConstant, str, int], db: float) -> None:
+        """Set Fairlight Mixer Input Mix Option
+
+        Args:
+            audioSource: see ATEMAudioSources
+            db (float): -100 to +10: volume in dB
+        """
+        audioSource_val = self.atem.getAudioSrc(audioSource)
+
+        self.switcher._prepareCommandPacket("CFSP", 48)
+        self.switcher._outBuf.setU16Flag(0, 7)
+        self.switcher._outBuf.setU16(2, audioSource_val)
+        self.switcher._outBuf.setS64(8, -65280) # Hacky fix to assume stereo
+
+        self.switcher._outBuf.setS32(40, int(db * 100))
+
+        self.switcher._finishCommandPacket()
+
+
+    def setFairlightMixerInputBalance(self, audioSource: Union[ATEMConstant, str, int], balance: float) -> None:
+        """Set Fairlight Mixer Input Balance
+
+        Args:
+            audioSource: see ATEMAudioSources
+            balance (float): -100 to 100: Left/Right Extremes
+        """
+        audioSource_val = self.atem.getAudioSrc(audioSource)
+
+        self.switcher._prepareCommandPacket("CFSP", 48)
+        self.switcher._outBuf.setU16Flag(0, 6)
+        self.switcher._outBuf.setU16(2, audioSource_val)
+        self.switcher._outBuf.setS64(8, -65280) # Hacky fix to assume stereo
+
+        self.switcher._outBuf.setS16(36, int(balance * 100))
+
+        self.switcher._finishCommandPacket()
+
+
+    def setFairlightMixerInputGain(self, audioSource: Union[ATEMConstant, str, int], gain: float) -> None:
+        """Set Fairlight Mixer Input Gain
+
+        Args:
+            audioSource: see ATEMAudioSources
+            gain (float): -100 to +6: gain in db
+        """
+        audioSource_val = self.atem.getAudioSrc(audioSource)
+
+        self.switcher._prepareCommandPacket("CFSP", 48)
+        self.switcher._outBuf.setU16Flag(0, 1)
+        self.switcher._outBuf.setU16(2, audioSource_val)
+        self.switcher._outBuf.setS64(8, -65280) # Hacky fix to assume stereo
+
+        self.switcher._outBuf.setS32(20, int(gain * 100))
+
+        self.switcher._finishCommandPacket()
+
+
+    def setFairlightMixerInputFramesDelay(self, audioSource: Union[ATEMConstant, str, int], delay: int) -> None:
+        """Set Fairlight Mixer Input Frames Delay
+
+        Args:
+            audioSource: see ATEMAudioSources
+            delay (int): 0 to `fairlightMixer.input[<audioSource>].maxFramesDelay`: delay in frames
+        """
+        audioSource_val = self.atem.getAudioSrc(audioSource)
+
+        self.switcher._prepareCommandPacket("CFSP", 48)
+        self.switcher._outBuf.setU16Flag(0, 0)
+        self.switcher._outBuf.setU16(2, audioSource_val)
+        self.switcher._outBuf.setS64(8, -65280) # Hacky fix to assume stereo
+
+        self.switcher._outBuf.setU8(16, delay)
+
+        self.switcher._finishCommandPacket()
+
+
+    def setFairlightMixerInputEQEnabled(self, audioSource: Union[ATEMConstant, str, int], enabled: bool) -> None:
+        """Enable or Disable EQ on an Input
+
+        Args:
+            audioSource: see ATEMAudioSources
+            enabled (bool): EQ enabled/disabled
+        """
+        audioSource_val = self.atem.getAudioSrc(audioSource)
+
+        self.switcher._prepareCommandPacket("CFSP", 48)
+        self.switcher._outBuf.setU16Flag(0, 3)
+        self.switcher._outBuf.setU16(2, audioSource_val)
+        self.switcher._outBuf.setS64(8, -65280) # Hacky fix to assume stereo
+
+        self.switcher._outBuf.setU8(26, enabled)
+
+        self.switcher._finishCommandPacket()
+
+
+    def setFairlightMixerInputEQGain(self, audioSource: Union[ATEMConstant, str, int], db: float) -> None:
+        """Set Input Gain for EQ
+
+        Args:
+            audioSource: see ATEMAudioSources
+            db (float): -20 to +20: gain in db
+        """
+        audioSource_val = self.atem.getAudioSrc(audioSource)
+
+        self.switcher._prepareCommandPacket("CFSP", 48)
+        self.switcher._outBuf.setU16Flag(0, 4)
+        self.switcher._outBuf.setU16(2, audioSource_val)
+        self.switcher._outBuf.setS64(8, -65280) # Hacky fix to assume stereo
+
+        self.switcher._outBuf.setS32(28, int(db * 100))
+
+        self.switcher._finishCommandPacket()
+
+
+    def setFairlightMixerInputEQBandEnabled(self, audioSource: Union[ATEMConstant, str, int], band: int, enabled: bool) -> None:
+        """Enable or Disable an Input EQ Band
+
+        Args:
+            audioSource: see ATEMAudioSources
+            band (int): Index of EQ band
+            enabled (bool): Band enabled/disabled
+        """
+        audioSource_val = self.atem.getAudioSrc(audioSource)
+
+        self.switcher._prepareCommandPacket("CEBP", 32)
+        self.switcher._outBuf.setU8Flag(0, 0)
+        self.switcher._outBuf.setU16(2, audioSource_val)
+        self.switcher._outBuf.setS64(8, -65280) # Hacky fix to assume stereo
+
+        self.switcher._outBuf.setU8(16, band)
+        self.switcher._outBuf.setU8(17, enabled)
+
+        self.switcher._finishCommandPacket()
+
+
+    def setFairlightMixerInputEQBandFilter(self, audioSource: Union[ATEMConstant, str, int], band: int, filterShape: Union[ATEMConstant, str, int]) -> None:
+        """Set Filter Shape of an Input EQ Band
+
+        Args:
+            audioSource: see ATEMAudioSources
+            band (int): Index of EQ band
+            filterShape: See ATEMFairlightEQFilters
+        """
+        audioSource_val = self.atem.getAudioSrc(audioSource)
+        filter_val = self.atem.fairlightEQFilters[filterShape].value
+
+        self.switcher._prepareCommandPacket("CEBP", 32)
+        self.switcher._outBuf.setU8Flag(0, 1)
+        self.switcher._outBuf.setU16(2, audioSource_val)
+        self.switcher._outBuf.setS64(8, -65280) # Hacky fix to assume stereo
+
+        self.switcher._outBuf.setU8(16, band)
+        self.switcher._outBuf.setU8(18, filter_val)
+
+        self.switcher._finishCommandPacket()
+
+
+    def setFairlightMixerInputEQBandFrequencyRange(self, audioSource: Union[ATEMConstant, str, int], band: int, frequencyRange: Union[ATEMConstant, str, int]) -> None:
+        """Set Frequency Range of an Input EQ Band
+
+        Args:
+            audioSource: see ATEMAudioSources
+            band (int): Index of EQ band
+            frequencyRange: See ATEMFairlightEQFrequencyRanges
+        """
+        audioSource_val = self.atem.getAudioSrc(audioSource)
+        freq_range_val = self.atem.fairlightEQFrequencyRanges[frequencyRange].value
+
+        self.switcher._prepareCommandPacket("CEBP", 32)
+        self.switcher._outBuf.setU8Flag(0, 2)
+        self.switcher._outBuf.setU16(2, audioSource_val)
+        self.switcher._outBuf.setS64(8, -65280) # Hacky fix to assume stereo
+
+        self.switcher._outBuf.setU8(16, band)
+        self.switcher._outBuf.setU8(19, freq_range_val)
+
+        self.switcher._finishCommandPacket()
+
+
+    def setFairlightMixerInputEQBandFrequency(self, audioSource: Union[ATEMConstant, str, int], band: int, frequency: int) -> None:
+        """Set Frequency of an Input EQ Band
+
+        Args:
+            audioSource: see ATEMAudioSources
+            band (int): Index of EQ band
+            frequency (int): +30 to +21700: frequency in Hz
+        """
+        audioSource_val = self.atem.getAudioSrc(audioSource)
+
+        self.switcher._prepareCommandPacket("CEBP", 32)
+        self.switcher._outBuf.setU8Flag(0, 3)
+        self.switcher._outBuf.setU16(2, audioSource_val)
+        self.switcher._outBuf.setS64(8, -65280) # Hacky fix to assume stereo
+
+        self.switcher._outBuf.setU8(16, band)
+        self.switcher._outBuf.setS32(20, frequency)
+
+        self.switcher._finishCommandPacket()
+
+
+    def setFairlightMixerInputEQBandGain(self, audioSource: Union[ATEMConstant, str, int], band: int, db: float) -> None:
+        """Set Gain of an Input EQ Band
+
+        Args:
+            audioSource: see ATEMAudioSources
+            band (int): Index of EQ band
+            db (float): -20 to +20: gain in db
+        """
+        audioSource_val = self.atem.getAudioSrc(audioSource)
+
+        self.switcher._prepareCommandPacket("CEBP", 32)
+        self.switcher._outBuf.setU8Flag(0, 4)
+        self.switcher._outBuf.setU16(2, audioSource_val)
+        self.switcher._outBuf.setS64(8, -65280) # Hacky fix to assume stereo
+
+        self.switcher._outBuf.setU8(16, band)
+        self.switcher._outBuf.setS32(24, int(db * 100))
+
+        self.switcher._finishCommandPacket()
+
+
+    def setFairlightMixerInputEQBandQFactor(self, audioSource: Union[ATEMConstant, str, int], band: int, qFactor: float) -> None:
+        """Set Q Factor of an Input EQ Band
+
+        Args:
+            audioSource: see ATEMAudioSources
+            band (int): Index of EQ band
+            db (float): -0.3 to +10.3: Q Factor
+        """
+        audioSource_val = self.atem.getAudioSrc(audioSource)
+
+        self.switcher._prepareCommandPacket("CEBP", 32)
+        self.switcher._outBuf.setU8Flag(0, 5)
+        self.switcher._outBuf.setU16(2, audioSource_val)
+        self.switcher._outBuf.setS64(8, -65280) # Hacky fix to assume stereo
+
+        self.switcher._outBuf.setU8(16, band)
+        self.switcher._outBuf.setS16(28, int(qFactor * 100))
+
+        self.switcher._finishCommandPacket()
+
+
+    def setFairlightMixerInputEQReset(self, audioSource: Union[ATEMConstant, str, int]) -> None:
+        """Reset an Input EQ
+        Args:
+            audioSource: see ATEMAudioSources
+        """
+        audioSource_val = self.atem.getAudioSrc(audioSource)
+
+        self.switcher._prepareCommandPacket("RICE", 20)
+        self.switcher._outBuf.setU8Flag(0, 0)
+        self.switcher._outBuf.setU16(2, audioSource_val)
+        self.switcher._outBuf.setS64(8, -65280) # Hacky fix to assume stereo
+
+        self.switcher._outBuf.setU8(16, True)
+
+        self.switcher._finishCommandPacket()
+
+
+    def setFairlightMixerInputEQBandReset(self, audioSource: Union[ATEMConstant, str, int], band: int) -> None:
+        """Reset an Input EQ band
+
+        Args:
+            audioSource: see ATEMAudioSources
+            band (int): Index of EQ band
+        """
+        audioSource_val = self.atem.getAudioSrc(audioSource)
+
+        self.switcher._prepareCommandPacket("RICE", 20)
+        self.switcher._outBuf.setU8Flag(0, 1)
+        self.switcher._outBuf.setU16(2, audioSource_val)
+        self.switcher._outBuf.setS64(8, -65280) # Hacky fix to assume stereo
+        self.switcher._outBuf.setU8(17, band)
+
+        self.switcher._finishCommandPacket()
+
+
+    def setFairlightMixerMasterVolume(self, db: float) -> None:
+        """Set Fairlight Mixer Master Volume
+
+        Args:
+            db (float): -100 to +10: volume in dB
+        """
+        self.switcher._prepareCommandPacket("CFMP", 20)
+        self.switcher._outBuf.setU8Flag(0, 3)
+
+        self.switcher._outBuf.setS32(12, int(db * 100))
+
+        self.switcher._finishCommandPacket()
+
+
+    def setFairlightMixerMasterFollowFTB(self, followFTB: bool) -> None:
+        """Set Fairlight Mixer Master Property 'Follow Fade To Black'
+
+        Args:
+            followFTB (bool): whether master mutes when FTB is active
+        """
+        self.switcher._prepareCommandPacket("CFMP", 20)
+        self.switcher._outBuf.setU8Flag(0, 4)
+
+        self.switcher._outBuf.setU8(16, followFTB)
+
+        self.switcher._finishCommandPacket()
+
+
+    def setFairlightMixerMasterEQEnabled(self, enabled: bool) -> None:
+        """Enable or Disable Master EQ
+
+        Args:
+            enabled (bool): EQ enabled/disabled
+        """
+        self.switcher._prepareCommandPacket("CFMP", 20)
+        self.switcher._outBuf.setU8Flag(0, 0)
+
+        self.switcher._outBuf.setU8(1, enabled)
+
+        self.switcher._finishCommandPacket()
+
+
+    def setFairlightMixerMasterEQGain(self, db: float) -> None:
+        """Set Master EQ Gain
+
+        Args:
+            db (float): -20 to +20: gain in db
+        """
+        self.switcher._prepareCommandPacket("CFMP", 20)
+        self.switcher._outBuf.setU8Flag(0, 1)
+
+        self.switcher._outBuf.setS32(4, int(db * 100))
+
+        self.switcher._finishCommandPacket()
+
+
+    def setFairlightMixerMasterEQBandEnabled(self, band: int, enabled: bool) -> None:
+        """Enable or Disable a MasterEQ Band
+
+        Args:
+            band (int): Index of EQ band
+            enabled (bool): Band enabled/disabled
+        """
+        self.switcher._prepareCommandPacket("CMBP", 20)
+        self.switcher._outBuf.setU8Flag(0, 0)
+        self.switcher._outBuf.setU8(1, band)
+
+        self.switcher._outBuf.setU8(2, enabled)
+
+        self.switcher._finishCommandPacket()
+
+
+    def setFairlightMixerMasterEQBandFilter(self, band: int, filterShape: Union[ATEMConstant, str, int]) -> None:
+        """Set Filter Shape of a Master EQ Band
+
+        Args:
+            band (int): Index of EQ band
+            filterShape: See ATEMFairlightEQFilters
+        """
+        filter_val = self.atem.fairlightEQFilters[filterShape].value
+
+        self.switcher._prepareCommandPacket("CMBP", 20)
+        self.switcher._outBuf.setU8Flag(0, 1)
+        self.switcher._outBuf.setU8(1, band)
+
+        self.switcher._outBuf.setU8(3, filter_val)
+
+        self.switcher._finishCommandPacket()
+
+
+    def setFairlightMixerMasterEQBandFrequencyRange(self, band: int, frequencyRange: Union[ATEMConstant, str, int]) -> None:
+        """Set Frequency Range of a Master EQ Band
+
+        Args:
+            band (int): Index of EQ band
+            frequencyRange: See ATEMFairlightEQFrequencyRanges
+        """
+        freq_range_val = self.atem.fairlightEQFrequencyRanges[frequencyRange].value
+
+        self.switcher._prepareCommandPacket("CMBP", 20)
+        self.switcher._outBuf.setU8Flag(0, 2)
+        self.switcher._outBuf.setU8(1, band)
+
+        self.switcher._outBuf.setU8(4, freq_range_val)
+
+        self.switcher._finishCommandPacket()
+
+    def setFairlightMixerMasterEQBandFrequency(self, band: int, frequency: int) -> None:
+        """Set Frequency of a Master EQ Band
+
+        Args:
+            band (int): Index of EQ band
+            frequency (int): +30 to +21700: frequency in Hz
+        """
+        self.switcher._prepareCommandPacket("CMBP", 20)
+        self.switcher._outBuf.setU8Flag(0, 3)
+        self.switcher._outBuf.setU8(1, band)
+
+        self.switcher._outBuf.setS32(8, frequency)
+
+        self.switcher._finishCommandPacket()
+
+
+    def setFairlightMixerMasterEQBandGain(self, band: int, db: float) -> None:
+        """Set Gain of a Master EQ Band
+
+        Args:
+            band (int): Index of EQ band
+            db (float): -20 to +20: gain in db
+        """
+        self.switcher._prepareCommandPacket("CMBP", 20)
+        self.switcher._outBuf.setU8Flag(0, 4)
+        self.switcher._outBuf.setU8(1, band)
+
+        self.switcher._outBuf.setS32(12, int(db * 100))
+
+        self.switcher._finishCommandPacket()
+
+
+    def setFairlightMixerMasterEQBandQFactor(self, band: int, qFactor: float) -> None:
+        """Set Q Factor of a Master EQ Band
+
+        Args:
+            band (int): Index of EQ band
+            db (float): -0.3 to +10.3: Q Factor
+        """
+        self.switcher._prepareCommandPacket("CMBP", 20)
+        self.switcher._outBuf.setU8Flag(0, 5)
+        self.switcher._outBuf.setU8(1, band)
+
+        self.switcher._outBuf.setS16(16, int(qFactor * 100))
+
+        self.switcher._finishCommandPacket()
+
+
+    def setFairlightMixerMasterEQReset(self) -> None:
+        """Reset Master EQ"""
+        self.switcher._prepareCommandPacket("RMOE", 4)
+        self.switcher._outBuf.setU8Flag(0, 0)
+        self.switcher._outBuf.setU8(1, True)
+
+        self.switcher._finishCommandPacket()
+
+
+    def setFairlightMixerMasterEQBandReset(self, band: int) -> None:
+        """Reset a Master EQ band
+
+        Args:
+            band (int): Index of EQ band
+        """
+        self.switcher._prepareCommandPacket("RMOE", 4)
+        self.switcher._outBuf.setU8Flag(0, 1)
+        self.switcher._outBuf.setU8(2, band)
+
+        self.switcher._finishCommandPacket()
+
+
+    def setFairlightLevelsEnable(self, enableLevels: bool):
+        """Set if the Fairlight Mixer should send us audio levels.
+
+        Be aware sending audio levels uses a significant amount of bandwidth
+        when active.
+
+        Args:
+            enableLevels (bool): whether the fairlight mixer should send audio levels to us
+        """
+        self.switcher._prepareCommandPacket("SFLN", 4)
+        self.switcher._outBuf.setU8(0, enableLevels)
+
         self.switcher._finishCommandPacket()

--- a/PyATEMMax/ATEMSwitcherState.py
+++ b/PyATEMMax/ATEMSwitcherState.py
@@ -27,6 +27,7 @@ class ATEMSwitcherState():
         self.downConverter:DownConverter = DownConverter()
         self.downstreamKeyer: DownStreamKeyerList = DownStreamKeyerList()
         self.fadeToBlack: FadeToBlackList = FadeToBlackList()
+        self.fairlightMixer: FairlightMixer = FairlightMixer()
         self.inputProperties: InputPropertiesList = InputPropertiesList()
         self.key: KeyList = KeyList()
         self.keyer: KeyerList = KeyerList()

--- a/PyATEMMax/ATEMUtils.py
+++ b/PyATEMMax/ATEMUtils.py
@@ -139,3 +139,17 @@ def mapValue(value:float, minFrom:float, maxFrom:float, minTo:float, maxTo:float
     rangeTo = maxTo - minTo
     scaled = (value - minFrom) / rangeFrom
     return minTo + (scaled * rangeTo)
+
+
+def getComponents(val: int) -> list[int]:
+    """Binary components of an integer
+
+    e.g. 7 (0b111) would return [0b100, 0b010, 0b001]
+    """
+    components = []
+    next_bit = 1
+    while next_bit <= val:
+        if (val & next_bit) > 0:
+            components.append(next_bit)
+        next_bit = next_bit << 1
+    return components

--- a/PyATEMMax/StateData/FairlightMixer.py
+++ b/PyATEMMax/StateData/FairlightMixer.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# coding: utf-8
+"""
+PyATEMMax state data: Fairlight Mixer
+Part of the PyATEMMax library.
+
+New implementation of the Fairlight Audio Mixer not included
+in the skaarhoj library.
+"""
+
+# pylint: disable=missing-class-docstring
+
+from PyATEMMax.ATEMProtocol import ATEMProtocol
+from PyATEMMax.ATEMConstant import ATEMConstant
+from PyATEMMax.ATEMValueDict import ATEMValueDict
+
+
+class FairlightMixer():
+    """Blackmagic ATEM switcher: fairlightAudioMixer state data"""
+
+    # #######################################################################
+    #
+    #  Class members
+    #
+
+    class Config():
+        def __init__(self): # FairlightMixer.Config
+            self.audioChannels: int = 0
+            self.hasMonitor: bool = False
+
+
+    class Equalizer():
+        def __init__(self): # FairlightMixer.Equalizer
+            self.enabled: bool = False
+            self.gain: int = 0
+            self.bandCount: int = 0
+            self.band: list[FairlightMixer.Equalizer.Band] = [self.Band()] * 6
+
+        class Band(): # FairlightMixer.Equalizer.Band
+            def __init__(self) -> None:
+                self.enabled: bool = False
+                self.supported_filters: list[ATEMConstant] = []
+                self.filter: ATEMConstant = ATEMConstant()
+                self.supported_frequency_ranges: list[ATEMConstant] = []
+                self.frequency_range: ATEMConstant = ATEMConstant()
+                self.frequency: int = 0
+                self.gain: float = 0.0
+                self.qFactor: float = 0.0
+
+
+    class Dynamics():
+        def __init__(self): # FairlightMixer.Dynamics
+            self.enabled: bool = False
+            self.makeUpGain: int = 0
+
+
+    class Input():
+        def __init__(self): # FairlightMixer.Input
+            self.maxFramesDelay: int = 0
+            self.hasStereoSimulation:bool = False
+            self.validMixOptions:list[int] = []
+
+            self.framesDelay: int = 0
+            self.stereoSimulation: int = 0
+            self.gain: float = 0
+            self.balance: float = 0.0
+            self.volume: float = 0
+            self.type: ATEMConstant = ATEMConstant()
+            self.mixOption: ATEMConstant = ATEMConstant()
+
+            self.equalizer: FairlightMixer.Equalizer = FairlightMixer.Equalizer()
+            self.dynamics: FairlightMixer.Dynamics = FairlightMixer.Dynamics()
+
+
+    class InputList(ATEMValueDict[Input]):
+        def __init__(self): # FairlightMixer.InputList
+            super().__init__(FairlightMixer.Input, ATEMProtocol.audioSources)
+
+
+    class Master():
+        def __init__(self): # FairlightMixer.Master
+            self.volume: float = 0
+            self.followFadeToBlack: bool = False
+
+            self.equalizer: FairlightMixer.Equalizer = FairlightMixer.Equalizer()
+            self.dynamics: FairlightMixer.Dynamics = FairlightMixer.Dynamics()
+
+
+    class Monitor():
+        # Future implementation
+        pass
+
+
+    class Levels():
+        # Future implementation
+        pass
+
+
+    class Tally():
+        # Future implementation
+        pass
+
+
+    def __init__(self): # FairlightMixer
+        self.config = FairlightMixer.Config()
+        self.input: FairlightMixer.InputList = FairlightMixer.InputList()
+        self.master: FairlightMixer.Master = FairlightMixer.Master()
+
+        # Future implementation
+        self.monitor = FairlightMixer.Monitor()
+        self.tally = FairlightMixer.Tally()
+        self.levels: FairlightMixer.Levels = FairlightMixer.Levels()

--- a/PyATEMMax/StateData/__init__.py
+++ b/PyATEMMax/StateData/__init__.py
@@ -14,6 +14,7 @@ from PyATEMMax.StateData.ColorGenerator import *
 from PyATEMMax.StateData.DownConverter import *
 from PyATEMMax.StateData.DownStreamKeyer import *
 from PyATEMMax.StateData.FadeToBlack import *
+from PyATEMMax.StateData.FairlightMixer import *
 from PyATEMMax.StateData.InputProperties import *
 from PyATEMMax.StateData.Key import *
 from PyATEMMax.StateData.Keyer import *


### PR DESCRIPTION
Added basic functionality for the new Fairlight Audio Mixer. All testing done on an Atem Mini Pro running the latest firmware.

### Features implemented so far:
- Input/Master Volume Control
- Input/Master Balance Control
- Input/Master EQ Control (EQ Enabled, EQ Gain, EQ Band Control...)
- Input Gain Control
- Input Mix Option Control
- Master link to FTB control

All features above have also been implemented in the switcher state, which is dynamically updated as packets are received by the client.